### PR TITLE
Fix PENS image url

### DIFF
--- a/_contents/pens.md
+++ b/_contents/pens.md
@@ -2,7 +2,7 @@
 name: Politeknik Elektronika Negeri Surabaya
 accreditation: A
 region: Surabaya
-image: "https://lh3.googleusercontent.com/proxy/S_WTpNSBP-k1mVSkm78DzkwrJ8K7eQ2yDPQj55IlPCpdRjPw_wFRTO1tnsltdmkj7lUwdz-OkgWf6-bazFLyElNzR8RC3u5USDxR9Daf8paHaK6X93sYO9Bxff7QGAmoXA"
+image: "https://upload.wikimedia.org/wikipedia/en/3/3a/Logo_Of_EEPIS.png"
 address: Institut Teknologi Sepuluh Nopember, Kampus, Jl. Raya ITS, Keputih, Kec. Sukolilo, Kota SBY, Jawa Timur 60111
 url: "https://www.pens.ac.id/"
 tag: PENS


### PR DESCRIPTION
previous url is a temporary url from google search and broken.