### PR TITLE
fix search input and scroll bug

### DIFF
--- a/_contents/unimed.md
+++ b/_contents/unimed.md
@@ -1,0 +1,9 @@
+---
+name: Universitas Negeri Medan
+accreditation: A
+region: Medan
+image: "https://www.unimed.ac.id/wp-content/uploads/2022/06/Logo-Unimed-dari-Corel.png"
+address: Jl. William Iskandar Ps. V, Kenangan Baru, Kec. Percut Sei Tuan, Kabupaten Deli Serdang, Sumatera Utara.
+url: "https://www.unimed.ac.id/"
+tag: Unimed
+---

--- a/components/Contents.js
+++ b/components/Contents.js
@@ -2,13 +2,10 @@ import Image from "next/image";
 import Router from "next/router";
 import Footer from "./Footer";
 
-export default function Contents({ data, dataCampus, setDataCampus }) {
+export default function Contents({ data, filter, setFilter }) {
   function search(e) {
-    Router.replace(`?search=${e.target.value}`);
-    setDataCampus({
-      ...dataCampus,
-      filters: e.target.value,
-    });
+    Router.replace(`?search=${encodeURI(e.target.value)}`, '', { scroll: false });
+    setFilter(e.target.value);
   }
 
   const imgLoader = ({ src }) => {
@@ -27,7 +24,7 @@ export default function Contents({ data, dataCampus, setDataCampus }) {
             type="text"
             placeholder="Search campus by name ..."
             onChange={search}
-            value={dataCampus.filters}
+            value={filter}
           />
           {data.length > 0 ? (
             data.map((item) => (

--- a/pages/index.js
+++ b/pages/index.js
@@ -7,24 +7,19 @@ import { useRouter } from "next/router";
 
 export default function Home({campus}) {
   const {query} = useRouter()
-  const [dataCampus, setDataCampus] = useState({
-    filteredData: campus,
-    filters: ""
-  });
+  const [dataCampus, setDataCampus] = useState(campus);
+  const [filter, setFilter] = useState("");
 
   useEffect(() => {
     if (query.search) {
-      const search = query.search?.toLowerCase() || dataCampus.filters.toLowerCase()
+      const search = query.search ? decodeURI(query.search.toLowerCase()) : ""
       const data = campus.filter(
         (data) =>
           data.name.toLowerCase().includes(search) ||
           data.tag.toLowerCase().includes(search)
       );
-      setDataCampus({
-        ...dataCampus,
-        filteredData: data,
-        filters: query.search ?? ""
-      });
+      setDataCampus(data);
+      setFilter(search);
       return () => {};
     }
   }, [query]);
@@ -47,9 +42,9 @@ export default function Home({campus}) {
         <div className="flex md:flex-row sm:flex-col flex-col w-full">
           <Sidebar />
           <Contents
-            dataCampus={dataCampus}
-            data={dataCampus.filteredData}
-            setDataCampus={setDataCampus}
+            data={dataCampus}
+            filter={filter}
+            setFilter={setFilter}
           />
         </div>
       </main>


### PR DESCRIPTION
Fix bug when typing space in search input and disable scroll to top when typing search query in search input.

Changes description:
- Separate `filter` and `dataCampus` state to make it clearer which state is responsible for keeping the data
- Make `search` only consider data from query params, since `filter` is already responsible for changing the query
- `setDataCampus` now is only responsible for changing the campuses data, and add `setFilter` for changing the filter
- `data` attribute on `Contents` component now takes `dataCampus` as value
- Since `Contents` doesn't need old `dataCampus.filters` and `setDataCampus` anymore, attributes changed to `filter` and `setFilter` and passed appropriate values.
- update `Router.replace()` function by encoding the search query first, and passing the options `{ scroll: false }` so page doesn't scroll to top when query updated.
- change `setDataCampus` to `setFilter`
- update `value` on search input to take `filter` data